### PR TITLE
Setting sponsor overflow to hidden

### DIFF
--- a/sass/style.scss
+++ b/sass/style.scss
@@ -433,6 +433,7 @@ img {
 
 .sponsor {
 	@include transition(all 0.2s);
+	overflow: hidden;
 	&:hover {
 		transform: scale(1.1,1.1);
 	}


### PR DESCRIPTION
This fixes the horizontal scrollbar appearing when hovering over some logos